### PR TITLE
buttonmasher-aggregator doesn't deploy

### DIFF
--- a/bootstrap/demo/federated/buttonmasher-service.yaml
+++ b/bootstrap/demo/federated/buttonmasher-service.yaml
@@ -69,3 +69,4 @@ spec:
   selector:
     app: buttonmasher-aggregator
   type: LoadBalancer
+---


### PR DESCRIPTION
The yaml file needed the --- at the end of the final service, or else it only created the first three.