### PR TITLE
Fix the following error:

### DIFF
--- a/aggregator/Makefile
+++ b/aggregator/Makefile
@@ -23,4 +23,4 @@ run:
 
 push: build
 	docker tag -f $(APP) gcr.io/$(PROJECT_ID)/$(APP)
-	gcloud docker push gcr.io/$(PROJECT_ID)/$(APP)
+	gcloud docker -- push gcr.io/$(PROJECT_ID)/$(APP)

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -25,15 +25,15 @@ run:
 
 push: build
 	docker tag -f $(APP) gcr.io/$(PROJECT_ID)/$(APP)
-	gcloud docker push gcr.io/$(PROJECT_ID)/$(APP)
+	gcloud docker -- push gcr.io/$(PROJECT_ID)/$(APP)
 
 push-v1: build
 	docker tag -f $(APP) gcr.io/$(PROJECT_ID)/$(APP):v1
-	gcloud docker push gcr.io/$(PROJECT_ID)/$(APP):v1
+	gcloud docker -- push gcr.io/$(PROJECT_ID)/$(APP):v1
 
 push-v2: build
 	docker tag -f $(APP) gcr.io/$(PROJECT_ID)/$(APP):v2
-	gcloud docker push gcr.io/$(PROJECT_ID)/$(APP):v2
+	gcloud docker -- push gcr.io/$(PROJECT_ID)/$(APP):v2
 
 clean:
 	rm -rf tmp/

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -23,7 +23,7 @@ run:
 
 push: build
 	docker tag $(APP) gcr.io/$(PROJECT_ID)/$(APP)
-	gcloud docker push gcr.io/$(PROJECT_ID)/$(APP)
+	gcloud docker -- push gcr.io/$(PROJECT_ID)/$(APP)
 
 deploy: push
 	kubectl scale rc buttonmasher-frontend --replicas=0

--- a/loader/Makefile
+++ b/loader/Makefile
@@ -20,4 +20,4 @@ build:
 
 push: build
 	docker tag $(APP) gcr.io/$(PROJECT_ID)/$(APP):v1
-	gcloud docker push gcr.io/$(PROJECT_ID)/$(APP):v1
+	gcloud docker -- push gcr.io/$(PROJECT_ID)/$(APP):v1

--- a/visualizer/Makefile
+++ b/visualizer/Makefile
@@ -23,4 +23,4 @@ run:
 
 push: build
 	docker tag $(APP) gcr.io/$(PROJECT_ID)/$(APP)
-	gcloud docker push gcr.io/$(PROJECT_ID)/$(APP)
+	gcloud docker -- push gcr.io/$(PROJECT_ID)/$(APP)


### PR DESCRIPTION
    WARNING: The '--' argument must be specified between gcloud specific args on the left and DOCKER_ARGS on the right. IMPORTANT: previously, commands allowed the omission of the --, and unparsed arguments were treated as implementation args. This usage is being deprecated and will be removed in March 2017.
    This will be strictly enforced in March 2017. Use 'gcloud beta docker' to see new behavior.